### PR TITLE
use values, not symbols

### DIFF
--- a/examples/physical-device-report.rkt
+++ b/examples/physical-device-report.rkt
@@ -56,7 +56,7 @@
   (vkDestroyInstance instance #f))
 
 (define (createInstance)
-  (define appInfo (make-VkApplicationInfo 'VK_STRUCTURE_TYPE_APPLICATION_INFO
+  (define appInfo (make-VkApplicationInfo VK_STRUCTURE_TYPE_APPLICATION_INFO
                                           #f
                                           #"Physical Device Report"
                                           0
@@ -65,7 +65,7 @@
                                           VK_API_VERSION_1_1))
 
   (define instinfo (make-VkInstanceCreateInfo
-                    'VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO
+                    VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO
                     #f
                     0
                     appInfo


### PR DESCRIPTION
Prior to this patch, I was getting this error:
```
ptr-set!: given value does not fit primitive C type
  C type: _ufixint
  value: 'VK_STRUCTURE_TYPE_APPLICATION_INFO
  context...:
   .../ffi/unsafe.rkt:1837:18: make-VkApplicationInfo
   C:\Users\dalev\Software\racket-vulkan\examples\physical-device-report.rkt:58:0: createInstance
   body of (submod "C:\Users\dalev\Software\racket-vulkan\examples\physical-device-report.rkt" main)
```