### PR TITLE
add missing 0 to comparison; null-terminate shader entry point name

### DIFF
--- a/examples/mandelbrot/mandelbrot-raw.rkt
+++ b/examples/mandelbrot/mandelbrot-raw.rkt
@@ -348,7 +348,8 @@
     (or (index-where ordinals
                      (λ (i)
                        (and (> (bitwise-and type-bits
-                                            (arithmetic-shift i 1)))
+                                            (arithmetic-shift i 1))
+                               0)
                             (= (bitwise-and
                                 (VkMemoryType-propertyFlags
                                  (array-ref
@@ -484,7 +485,7 @@
   (set-VkPipelineShaderStageCreateInfo-sType! ssci VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO)
   (set-VkPipelineShaderStageCreateInfo-stage! ssci VK_SHADER_STAGE_COMPUTE_BIT)
   (set-VkPipelineShaderStageCreateInfo-module! ssci shader-module)
-  (set-VkPipelineShaderStageCreateInfo-pName! ssci #"main")
+  (set-VkPipelineShaderStageCreateInfo-pName! ssci #"main\0")
 
   (define pci/p (make-zero _VkComputePipelineCreateInfo _VkComputePipelineCreateInfo-pointer))
   (define pci (ptr-ref pci/p _VkComputePipelineCreateInfo))

--- a/examples/mandelbrot/mandelbrot.rkt
+++ b/examples/mandelbrot/mandelbrot.rkt
@@ -347,7 +347,8 @@
     (or (index-where ordinals
                      (λ (i)
                        (and (> (bitwise-and type-bits
-                                            (arithmetic-shift i 1)))
+                                            (arithmetic-shift i 1))
+                               0)
                             (= (bitwise-and
                                 (VkMemoryType-propertyFlags
                                  (array-ref
@@ -483,7 +484,7 @@
   (set-VkPipelineShaderStageCreateInfo-sType! ssci 'VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO)
   (set-VkPipelineShaderStageCreateInfo-stage! ssci 'VK_SHADER_STAGE_COMPUTE_BIT)
   (set-VkPipelineShaderStageCreateInfo-module! ssci shader-module)
-  (set-VkPipelineShaderStageCreateInfo-pName! ssci #"main")
+  (set-VkPipelineShaderStageCreateInfo-pName! ssci #"main\0")
 
   (define pci/p (make-zero _VkComputePipelineCreateInfo _VkComputePipelineCreateInfo-pointer))
   (define pci (ptr-ref pci/p _VkComputePipelineCreateInfo))


### PR DESCRIPTION
Two fixes:
- add missing 0 from comparison operation.
- shader entry point needs to be null terminated

Regarding the latter: it may be possible to enhance the generator to use `_bytes/nul-terminated` rather than `_pointer` as the type of the `pName` field in the struct `VkPipelineShaderStageCreateInfo`.  Then the FFI would automatically take care of this.  I don't currently have plans to look into that.